### PR TITLE
Update GitHub Actions dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,17 +15,17 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Check out repository
-        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
+        uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9
         with:
           version: 11.17.0
 
       - name: Set up Node.js
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version-file: .node-version
           cache: pnpm

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Install uv
-        uses: astral-sh/setup-uv@08807647e7069bb48b6ef5acd8ec9567f424441b # v8.1.0
+        uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
 
       - name: Run zizmor
         run: uvx zizmor --format=github .


### PR DESCRIPTION
## Summary

- consolidate the updates proposed by Dependabot PRs #1648, #1649, #1650, and #1651
- update `actions/checkout` to v7.0.1, `actions/setup-node` to v7.0.0, and `pnpm/action-setup` to v6.0.9
- update `astral-sh/setup-uv` to v9.0.0, superseding Dependabot's v8.3.2 proposal
- keep every GitHub Action pinned to its immutable release commit

## Dependency review

The current Astro application dependencies, development dependencies, Node 24 LTS patch, and pnpm 11 release were checked against their upstream registries. No additional updates are available, and the active pnpm lockfile reports no known vulnerabilities.

## Validation

- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm outdated --format json` (empty result)
- `corepack pnpm audit --json` (0 vulnerabilities)
- `corepack pnpm check`
- `uvx zizmor --format=github .`
