### PR TITLE
Enable Worker caching and observability

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -4,6 +4,24 @@
   "compatibility_date": "2026-07-26",
   "workers_dev": true,
   "preview_urls": true,
+  "cache": {
+    "enabled": true,
+  },
+  "observability": {
+    "enabled": true,
+    "head_sampling_rate": 1,
+    "logs": {
+      "enabled": true,
+      "head_sampling_rate": 1,
+      "persist": true,
+      "invocation_logs": true,
+    },
+    "traces": {
+      "enabled": false,
+      "persist": true,
+      "head_sampling_rate": 1,
+    },
+  },
   "routes": [
     {
       "pattern": "nerd-ramblings.com",


### PR DESCRIPTION
## What changed

- enable the new Workers cache with version-scoped invalidation
- enable persisted Workers observability at a 100% head sampling rate
- retain invocation logs
- leave automatic tracing disabled

## Why

This makes the Wrangler configuration the source of truth for caching and observability instead of relying on dashboard-only settings. Cross-version caching remains disabled so a deployment naturally starts with a fresh cache namespace.

## Validation

- `pnpm check`
- `wrangler deploy --dry-run`

Cloudflare documentation:

- https://developers.cloudflare.com/workers/cache/configuration/
- https://developers.cloudflare.com/workers/wrangler/configuration/#observability
